### PR TITLE
Fix container doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Celluloid.supervise as: :my_actor, type: MyActor, args: [:one_arg, :two_args]
 # Using containers.
 
 ```ruby
-container = Celluloid::Supervision::Container.new {
+class MyContainer < Celluloid::Supervision::Container
   supervise type: MyActor, as: :my_actor
   supervise type: MyActor, as: :my_actor_with_args, args: [:one_arg, :two_args]
-}
-container.run!
+end
+MyContainer.run!
 ```
 
 # Using configuration objects:


### PR DESCRIPTION
The first example:

```
container = Celluloid::Supervision::Container.new {
  supervise type: MyActor, as: :my_actor
}
container.run!
```

failed with the error:

```
NoMethodError: undefined method `supervise' for main:Object
```

`Celluloid::Supervision::Container` initialization supports yielding with
the new object as an argument, but changing the example to:

```
container = Celluloid::Supervision::Container.new { |a|
  a.supervise type: MyActor, as: :my_actor
}
container.run!
```

failed with the error:

```
undefined method `run!' for #<Celluloid::Supervision::Container:0x3fe78d9fe1d8> (NoMethodError)
```

because `run!` is defined as a class method.

The way that I found useful to use supervision containers was to subclass
`Celluloid::Supervision::Container`, define actors supervision, and run it,
in a similar way to how `Celluloid::SupervisionGroup` worked before
Celluloid 0.17.

See also https://github.com/celluloid/celluloid/wiki/Supervision%20Groups
